### PR TITLE
Fix reading metadata file

### DIFF
--- a/bin/khaos-create
+++ b/bin/khaos-create
@@ -139,7 +139,7 @@ function options(dir){
   if (!file) return {};
 
   try {
-    return metadata(file);
+    return metadata.sync(file);
   } catch (e) {
     logger.fatal('Invalid metadata in ' + file);
   }


### PR DESCRIPTION
Need to call the `.sync` function, otherwise it does it asynchronously and there's nothing to return
