### PR TITLE
upgrade `to-case` module to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "rimraf": "^2.2.6",
     "sort-object": "^3.0.0",
     "thunkify": "^2.1.2",
-    "to-case": "^1.0.0",
+    "to-case": "^2.0.0",
     "uid": "~0.0.2",
     "unyield": "0.0.1"
   },


### PR DESCRIPTION
`npm install khaos` error when the to-case module is v1.0.0

``` js
$ npm i khaos
npm WARN deprecated metalsmith-templates@0.7.0: This package was split into two simpler plugins: metalsmith-layouts and metalsmith-in-place
npm ERR! git clone http://github.com/ianstormtaylor/to-camel-case Initialized empty Git repository in /root/.npm/_git-remotes/http-github-com-ianstormtaylor-to-camel-case-f206d7eb/
npm ERR! git clone http://github.com/ianstormtaylor/to-camel-case 
npm ERR! git clone http://github.com/ianstormtaylor/to-camel-case error:  while accessing http://github.com/ianstormtaylor/to-camel-case/info/refs
npm ERR! git clone http://github.com/ianstormtaylor/to-camel-case 
npm ERR! git clone http://github.com/ianstormtaylor/to-camel-case fatal: HTTP request failed
npm WARN deprecated graceful-fs@3.0.8: graceful-fs version 3 and before will fail on newer node releases. Please update to graceful-fs@^4.0.0 as soon as possible.
npm ERR! Error: Command failed: error:  while accessing http://github.com/ianstormtaylor/to-camel-case/info/refs
npm ERR! 
npm ERR! fatal: HTTP request failed
...
```
